### PR TITLE
Add interactive branch directory web app

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,223 @@
+const branches = [
+  {
+    name: "한마음선원 본원",
+    region: "경기도 안양 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "https://www.hanmaum.org",
+  },
+  {
+    name: "서울 지원",
+    region: "서울 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "부산 지원",
+    region: "부산 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "대구 지원",
+    region: "대구 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "광주 지원",
+    region: "광주 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "대전 지원",
+    region: "대전 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "울산 지원",
+    region: "울산 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "인천 지원",
+    region: "인천 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "수원 지원",
+    region: "경기도 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "성남 지원",
+    region: "경기도 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "춘천 지원",
+    region: "강원도 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "청주 지원",
+    region: "충청북도 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "전주 지원",
+    region: "전라북도 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "제주 지원",
+    region: "제주도 · 국내",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "뉴욕 지원",
+    region: "미국 · 국외",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "LA 지원",
+    region: "미국 · 국외",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "시카고 지원",
+    region: "미국 · 국외",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "토론토 지원",
+    region: "캐나다 · 국외",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "밴쿠버 지원",
+    region: "캐나다 · 국외",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "시드니 지원",
+    region: "호주 · 국외",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+  {
+    name: "런던 지원",
+    region: "영국 · 국외",
+    phone: "정보 준비 중",
+    address: "정보 준비 중",
+    website: "정보 준비 중",
+  },
+];
+
+const listElement = document.querySelector("#branch-list");
+const template = document.querySelector("#branch-card");
+const searchInput = document.querySelector("#search");
+
+const normalize = (value) => value.replace(/\s+/g, "").toLowerCase();
+
+const buildMapUrl = (branch) => {
+  const query = encodeURIComponent(`${branch.name} ${branch.address}`);
+  return `https://www.google.com/maps/search/?api=1&query=${query}`;
+};
+
+const buildPhoneLink = (phone) => {
+  if (!phone || phone.includes("정보")) {
+    return null;
+  }
+  return `tel:${phone.replace(/[^\d+]/g, "")}`;
+};
+
+const renderBranches = (items) => {
+  listElement.innerHTML = "";
+
+  items.forEach((branch) => {
+    const clone = template.content.cloneNode(true);
+    const card = clone.querySelector(".branch-card");
+    const header = clone.querySelector(".branch-card__header");
+
+    clone.querySelector(".branch-card__name").textContent = branch.name;
+    clone.querySelector(".branch-card__region").textContent = branch.region;
+
+    const phoneElement = clone.querySelector(".detail__phone");
+    phoneElement.textContent = branch.phone;
+    const phoneLink = buildPhoneLink(branch.phone);
+    if (phoneLink) {
+      phoneElement.href = phoneLink;
+    } else {
+      phoneElement.removeAttribute("href");
+    }
+
+    clone.querySelector(".detail__address").textContent = branch.address;
+
+    const mapLink = clone.querySelector(".detail__map");
+    mapLink.href = buildMapUrl(branch);
+
+    const siteLink = clone.querySelector(".detail__site");
+    if (branch.website.includes("정보")) {
+      siteLink.textContent = "정보 준비 중";
+      siteLink.removeAttribute("href");
+    } else {
+      siteLink.textContent = branch.website;
+      siteLink.href = branch.website;
+    }
+
+    header.addEventListener("click", () => {
+      card.classList.toggle("is-open");
+    });
+
+    listElement.appendChild(clone);
+  });
+};
+
+const filterBranches = () => {
+  const query = normalize(searchInput.value);
+  const filtered = branches.filter((branch) => {
+    if (!query) return true;
+    const haystack = normalize(`${branch.name}${branch.region}${branch.address}`);
+    return haystack.includes(query);
+  });
+  renderBranches(filtered);
+};
+
+searchInput.addEventListener("input", filterBranches);
+
+renderBranches(branches);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>한마음선원 지원 안내</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <p class="hero__eyebrow">대한불교 조계종 한마음선원</p>
+        <h1>국내·국외 지원 안내</h1>
+        <p>
+          본원을 포함해 20여 곳 이상의 지원 정보를 한눈에 확인하세요. 각 지원을
+          클릭하면 전화번호, 주소, 구글지도 위치, 웹사이트를 바로 확인할 수
+          있습니다.
+        </p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="controls">
+        <label class="search">
+          <span>지원 검색</span>
+          <input id="search" type="search" placeholder="지원 이름 또는 지역 검색" />
+        </label>
+        <div class="legend">
+          <span class="badge badge--korea">국내</span>
+          <span class="badge badge--overseas">국외</span>
+        </div>
+      </section>
+
+      <section id="branch-list" class="branch-list" aria-live="polite"></section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        정보는 최신화를 위해 상시 업데이트될 수 있습니다. 정확한 정보는 각 지원
+        웹사이트 또는 전화로 확인하세요.
+      </p>
+    </footer>
+
+    <template id="branch-card">
+      <article class="branch-card">
+        <button class="branch-card__header" type="button">
+          <div>
+            <h2 class="branch-card__name"></h2>
+            <p class="branch-card__region"></p>
+          </div>
+          <span class="branch-card__toggle">자세히 보기</span>
+        </button>
+        <div class="branch-card__details">
+          <div class="detail">
+            <span>전화번호</span>
+            <a class="detail__phone" href="#"></a>
+          </div>
+          <div class="detail">
+            <span>주소</span>
+            <p class="detail__address"></p>
+          </div>
+          <div class="detail">
+            <span>구글지도</span>
+            <a class="detail__map" href="#" target="_blank" rel="noreferrer">지도 보기</a>
+          </div>
+          <div class="detail">
+            <span>웹사이트</span>
+            <a class="detail__site" href="#" target="_blank" rel="noreferrer">웹사이트 방문</a>
+          </div>
+        </div>
+      </article>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,212 @@
+:root {
+  color-scheme: light;
+  --text: #1b1b1b;
+  --muted: #5c5c5c;
+  --bg: #f7f6f4;
+  --card: #ffffff;
+  --accent: #52796f;
+  --accent-light: #e0ebe6;
+  --border: #e2e2e2;
+  font-family: "Pretendard", "Noto Sans KR", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.hero {
+  background: linear-gradient(135deg, #f0f4f1, #dfe8e5);
+  padding: 48px 24px 32px;
+}
+
+.hero__content {
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  font-size: 12px;
+  margin: 0 0 8px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(28px, 4vw, 40px);
+}
+
+.hero p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 720px;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.search {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 320px;
+  font-weight: 600;
+}
+
+.search input {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 12px 16px;
+  font-size: 15px;
+  background: #fff;
+}
+
+.legend {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge--korea {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.badge--overseas {
+  background: #f5e9da;
+  color: #a36a2a;
+}
+
+.branch-list {
+  display: grid;
+  gap: 16px;
+}
+
+.branch-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.04);
+}
+
+.branch-card__header {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 18px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-align: left;
+  cursor: pointer;
+}
+
+.branch-card__name {
+  margin: 0;
+  font-size: 20px;
+}
+
+.branch-card__region {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.branch-card__toggle {
+  background: var(--accent-light);
+  color: var(--accent);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.branch-card__details {
+  display: grid;
+  gap: 16px;
+  padding: 0 20px 20px;
+  border-top: 1px solid var(--border);
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: all 0.25s ease;
+}
+
+.branch-card.is-open .branch-card__details {
+  max-height: 400px;
+  opacity: 1;
+  padding-top: 16px;
+}
+
+.detail {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 12px;
+  align-items: start;
+  font-size: 14px;
+}
+
+.detail span {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.detail a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.detail a:hover {
+  text-decoration: underline;
+}
+
+.footer {
+  text-align: center;
+  padding: 24px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+@media (max-width: 640px) {
+  .controls {
+    align-items: stretch;
+  }
+
+  .detail {
+    grid-template-columns: 1fr;
+  }
+
+  .branch-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight static web app to list 한마음선원 supports (국내·국외) so users can click a branch to see phone, address, Google Maps location and website.
- Allow quick lookup via a client-side search and expand/collapse UI for each branch card.
- Seed the directory with ~20 branch entries using placeholder contact data to be replaced with verified details later.

### Description
- Added `index.html` which contains the page structure, search control, and a `<template id="branch-card">` for expandable branch cards.
- Added `styles.css` to style the hero, controls, responsive grid and the expandable card UI.
- Added `app.js` to render a `branches` array, implement client-side filtering (`search` input), expand/collapse behavior, and helper functions to build Google Maps and `tel:` links for each branch.
- Branch entries include placeholders (`정보 준비 중`) for phone/address/website where data is pending and can be filled later.

### Testing
- Started a local static server with `python -m http.server 8000 --directory /workspace/chul`, which launched (PID shown in session) to serve the new files.
- Attempted an automated screenshot with Playwright, but the Chromium launch crashed (reported `TargetClosedError` / SIGSEGV), so the end-to-end screenshot step failed.
- No unit or integration test suite was run; `git` add/commit ran successfully to record the new files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698567670e4483258b5c0f624a0fb3c1)