### PR TITLE
Create Hanmaum Seonwon support directory app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>한마음선원 국내외 지원 안내</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="page-header">
+    <div class="header-content">
+      <h1>한마음선원 국내외 지원 안내</h1>
+      <p>
+        전국과 해외에 위치한 한마음선원 지원의 연락처와 주소, 구글 지도를 한눈에 확인해 보세요.
+        각 지원을 선택하면 자세한 정보를 확인하고 지도로 위치를 확인할 수 있습니다.
+      </p>
+    </div>
+  </header>
+
+  <main>
+    <section class="support-section" id="domestic-section">
+      <div class="section-title">
+        <h2>국내 지원</h2>
+        <p>전국 15개의 지원을 찾아보세요.</p>
+      </div>
+      <div class="support-layout" data-section="domestic">
+        <div class="support-list" id="domestic-list" aria-label="국내 지원 목록"></div>
+        <div class="support-detail" id="domestic-detail" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section class="support-section" id="global-section">
+      <div class="section-title">
+        <h2>국외 지원</h2>
+        <p>해외 10개의 지원을 지역별로 살펴보세요.</p>
+      </div>
+      <div class="support-layout" data-section="global">
+        <div class="support-list" id="global-list" aria-label="국외 지원 목록"></div>
+        <div class="support-detail" id="global-detail" aria-live="polite"></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>자료 출처: 한마음선원 공식 홈페이지.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,383 @@
+const domesticSupports = [
+  {
+    name: "강릉지원",
+    address: "(우) 25565 강원도 강릉시 하평 5길 29 (포남 2동 1304)",
+    phones: ["(033)651-3003"],
+    faxes: ["(033)652-0281"],
+    website: "https://gng.hanmaum.org/"
+  },
+  {
+    name: "공주지원",
+    address: "(우) 32522 충청남도 공주시 사곡면 위안양골길 157-61 (신영3리 152-3)",
+    phones: ["(041)852-9100"],
+    faxes: ["(041)852-9105"],
+    website: "https://gju.hanmaum.org/"
+  },
+  {
+    name: "광명선원",
+    address: "(우) 27638 충청북도 음성군 금왕읍 대금로 1402 (무극리 559-13)",
+    phones: ["(043)877-5000"],
+    faxes: ["(043)877-2900"],
+    website: "https://gm.hanmaum.org/"
+  },
+  {
+    name: "광주지원",
+    address: "(우) 61965 광주광역시 서구 운천로 204번길 23-1 (치평동 201-5)",
+    phones: ["(062)373-8801"],
+    faxes: ["(062)373-0174"],
+    website: "https://gwj.hanmaum.org/"
+  },
+  {
+    name: "대구지원",
+    address: "(우) 42152 대구광역시 수성구 수성로 41길 76 (중동 532-274)",
+    phones: ["(053)767-3100"],
+    faxes: ["(053)765-1600"],
+    website: "https://dgu.hanmaum.org/"
+  },
+  {
+    name: "목포지원",
+    address: "(우) 58696 전라남도 목포시 백년대로 266번길 31-1(상동 952-19)",
+    phones: ["(061)284-1771"],
+    faxes: ["(061)284-1770"],
+    website: "https://mp.hanmaum.org/"
+  },
+  {
+    name: "문경지원",
+    address: "(우) 36937 경상북도 문경시 산양면 봉서1길 10(반곡리 44)",
+    phones: ["(054)555-8871"],
+    faxes: ["(054)556-1989"],
+    website: "https://myg.hanmaum.org/"
+  },
+  {
+    name: "부산지원",
+    address: "(우) 49113 부산광역시 영도구 함지로 79번길 23-26 (동삼동 522-1)",
+    phones: ["(051)403-7077"],
+    faxes: ["(051)403-1077"],
+    website: "https://bs.hanmaum.org/"
+  },
+  {
+    name: "울산지원",
+    address: "(우) 44200 울산광역시 북구 달래골길 26-12 (천곡동 927-7)",
+    phones: ["(052)295-2335"],
+    faxes: ["(052)295-2336"],
+    website: "https://us.hanmaum.org/"
+  },
+  {
+    name: "제주지원",
+    address: "(우) 63308 제주도 제주시 황사평 6길 176-1 (영평동 1500)",
+    phones: ["(064)727-3100"],
+    faxes: ["(064)727-0302"],
+    website: "https://jej.hanmaum.org/"
+  },
+  {
+    name: "중부경남지원",
+    address: "(우) 50871 경상남도 김해시 진영읍 하계로 35 (방동리 321-1)",
+    phones: ["(055)345-9900"],
+    faxes: ["(055)346-2179"],
+    website: "https://mkn.hanmaum.org/"
+  },
+  {
+    name: "진주지원",
+    address: "(우) 52602 경상남도 진주시 미천면 오방로 528-40 (오방리 50)",
+    phones: ["(055)746-8163"],
+    faxes: ["(055)746-7825"],
+    website: "https://jju.hanmaum.org/"
+  },
+  {
+    name: "청주지원",
+    address: "(우) 28540 충청북도 청주시 청원구 교서로 109 (우암동 295-7)",
+    phones: ["(043)259-5599"],
+    faxes: ["(043)255-5599"],
+    website: "https://cju.hanmaum.org/"
+  },
+  {
+    name: "통영지원",
+    address: "(우) 53021 경상남도 통영시 광도면 조암길 45-230",
+    phones: ["(055)643-0643"],
+    faxes: ["(055)643-0642"],
+    website: "https://ty.hanmaum.org/"
+  },
+  {
+    name: "포항지원",
+    address: "(우) 37635 경상북도 포항시 북구 우창로 59 (우현동 13-1)",
+    phones: ["(054)232-3163"],
+    faxes: ["(054)241-3503"],
+    website: "https://phg.hanmaum.org/"
+  }
+];
+
+const globalSupports = [
+  {
+    region: "독일",
+    name: "독일지원",
+    address: "Broicherdorf Str. 102, 41564 Kaarst, Germany",
+    phones: ["(49-2131)969551"],
+    faxes: ["(49-2131)969552"],
+    website: "https://ger.hanmaum.org/"
+  },
+  {
+    region: "미국",
+    name: "뉴욕지원",
+    address: "144-39, 32 Ave. Flushing, NY 11354, USA",
+    phones: ["070-7899-5899", "(1-718)460-2019"],
+    faxes: ["(1-718)939-3974"],
+    website: "https://nyk.hanmaum.org/"
+  },
+  {
+    region: "미국",
+    name: "로스엔젤레스지원",
+    address: "1905, S. Victoria Ave. L.A., CA 90016, USA",
+    phones: ["(1-323)766-1316"],
+    website: "https://la.hanmaum.org/"
+  },
+  {
+    region: "미국",
+    name: "시카고지원",
+    address: "854 RIVERWOODS RD. METTAWA, IL, 60045 USA",
+    phones: ["(1-224)632-0959"],
+    website: "https://chi.hanmaum.org/"
+  },
+  {
+    region: "미국",
+    name: "워싱턴지원",
+    address: "10303 Burke Lake Rd. Fairfax Station, VA 22039",
+    phones: ["(1-703)560-5166"],
+    faxes: ["(1-703)560-5166"],
+    website: "https://wah.hanmaum.org/"
+  },
+  {
+    region: "아르헨티나",
+    name: "부에노스 아이레스지원",
+    address: "Miró 1575, CABA, C1406CVE, República Argentina",
+    phones: ["(54-11)4921-9286"],
+    website: "http://hanmaumbsas.org/"
+  },
+  {
+    region: "아르헨티나",
+    name: "뚜꾸만지원",
+    address: "Av. Aconquija 5250, El Corte, Yerba Buena, T4107CHN, Tucumán, Argentina",
+    phones: ["54-381-408-2894"],
+    website: "https://tuc.hanmaum.org/"
+  },
+  {
+    region: "브라질",
+    name: "상파울로지원",
+    address: "Rua Muniz de Sousa, 1296-Aclimação, São Paulo -SP, 01534-001, Brasil"
+  },
+  {
+    region: "캐나다",
+    name: "토론토지원",
+    address: "20 Mobile Drive North York, Ontario M4A 1H9 CANADA",
+    phones: ["(1-416)750-7943"],
+    faxes: ["(1-416)981-7815"],
+    website: "https://tor.hanmaum.org/"
+  },
+  {
+    region: "태국",
+    name: "태국지원",
+    address: "86/1 Soi 4 Ekkamai, Sukhumvit 63Rd. Bangkok 10110, Thailand",
+    phones: ["66) 61-413-7000"],
+    website: "https://thi.hanmaum.org/"
+  }
+];
+
+function renderSupportSection(data, listId, detailId) {
+  const listEl = document.getElementById(listId);
+  const detailEl = document.getElementById(detailId);
+
+  if (!listEl || !detailEl) return;
+
+  let activeCard = null;
+
+  data.forEach((entry, index) => {
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = "support-card";
+    card.setAttribute("data-index", String(index));
+
+    const nameWrapper = document.createElement("div");
+    nameWrapper.className = "name";
+    nameWrapper.textContent = entry.name;
+
+    if (entry.region) {
+      const regionBadge = document.createElement("span");
+      regionBadge.className = "region";
+      regionBadge.textContent = entry.region;
+      nameWrapper.appendChild(regionBadge);
+    }
+
+    const summary = document.createElement("div");
+    summary.className = "summary";
+    const addressLine = entry.address || "주소 정보 없음";
+    const contactLine = entry.phones && entry.phones.length > 0
+      ? `☎ ${entry.phones[0]}`
+      : entry.faxes && entry.faxes.length > 0
+        ? `Fax ${entry.faxes[0]}`
+        : "연락처 정보 없음";
+    summary.innerHTML = `${addressLine}<br>${contactLine}`;
+
+    card.append(nameWrapper, summary);
+
+    card.addEventListener("click", () => {
+      if (activeCard) {
+        activeCard.classList.remove("active");
+      }
+      card.classList.add("active");
+      activeCard = card;
+      renderDetail(entry, detailEl);
+    });
+
+    listEl.appendChild(card);
+
+    if (index === 0) {
+      card.classList.add("active");
+      activeCard = card;
+      renderDetail(entry, detailEl);
+    }
+  });
+}
+
+function renderDetail(entry, container) {
+  container.innerHTML = "";
+
+  const header = document.createElement("div");
+  header.className = "detail-header";
+
+  const title = document.createElement("h3");
+  title.textContent = entry.name;
+  header.appendChild(title);
+
+  if (entry.region) {
+    const region = document.createElement("span");
+    region.className = "region-tag";
+    region.textContent = entry.region;
+    header.appendChild(region);
+  }
+
+  const body = document.createElement("div");
+  body.className = "detail-body";
+
+  const addressBlock = createInfoBlock("주소", entry.address || "주소 정보가 등록되어 있지 않습니다.");
+  body.appendChild(addressBlock);
+
+  if (entry.phones && entry.phones.length > 0) {
+    body.appendChild(createListBlock("전화", entry.phones, true));
+  }
+
+  if (entry.faxes && entry.faxes.length > 0) {
+    body.appendChild(createListBlock("팩스", entry.faxes, false));
+  }
+
+  if ((!entry.phones || entry.phones.length === 0) && (!entry.faxes || entry.faxes.length === 0)) {
+    body.appendChild(createInfoBlock("연락처", "등록된 연락처 정보가 없습니다."));
+  }
+
+  if (entry.website) {
+    const websiteBlock = document.createElement("dl");
+    websiteBlock.className = "info-block";
+    const dt = document.createElement("dt");
+    dt.textContent = "홈페이지";
+    const dd = document.createElement("dd");
+    const link = document.createElement("a");
+    link.href = entry.website;
+    link.target = "_blank";
+    link.rel = "noopener";
+    link.textContent = entry.website.replace(/^https?:\/\//, "");
+    dd.appendChild(link);
+    websiteBlock.append(dt, dd);
+    body.appendChild(websiteBlock);
+  }
+
+  const mapLink = document.createElement("a");
+  mapLink.className = "map-link";
+  mapLink.href = createMapSearchUrl(entry);
+  mapLink.target = "_blank";
+  mapLink.rel = "noopener";
+  mapLink.textContent = "구글 지도에서 보기";
+
+  const mapContainer = document.createElement("div");
+  mapContainer.className = "map-container";
+  const iframe = document.createElement("iframe");
+  iframe.loading = "lazy";
+  iframe.src = createMapEmbedUrl(entry);
+  iframe.title = `${entry.name} 위치 지도`;
+  mapContainer.appendChild(iframe);
+
+  container.append(header, body, mapLink, mapContainer);
+}
+
+function createInfoBlock(label, text) {
+  const block = document.createElement("dl");
+  block.className = "info-block";
+  const dt = document.createElement("dt");
+  dt.textContent = label;
+  const dd = document.createElement("dd");
+  dd.textContent = text;
+  block.append(dt, dd);
+  return block;
+}
+
+function createListBlock(label, items, withTelLinks) {
+  const block = document.createElement("dl");
+  block.className = "info-block";
+  const dt = document.createElement("dt");
+  dt.textContent = label;
+  block.appendChild(dt);
+
+  items.forEach((item) => {
+    const dd = document.createElement("dd");
+    if (withTelLinks) {
+      const href = buildTelHref(item);
+      if (href) {
+        const link = document.createElement("a");
+        link.href = href;
+        link.textContent = item;
+        link.className = "contact-link";
+        dd.appendChild(link);
+      } else {
+        dd.textContent = item;
+      }
+    } else {
+      dd.textContent = item;
+    }
+    block.appendChild(dd);
+  });
+
+  return block;
+}
+
+function buildTelHref(value) {
+  const cleaned = value.replace(/[^0-9+]/g, "");
+  if (!cleaned) {
+    return null;
+  }
+
+  if (cleaned.startsWith("00")) {
+    return `tel:+${cleaned.slice(2)}`;
+  }
+
+  return `tel:${cleaned}`;
+}
+
+function createMapQuery(entry) {
+  const parts = [];
+  if (entry.address) parts.push(entry.address);
+  if (entry.region && !entry.address?.includes(entry.region)) parts.push(entry.region);
+  parts.push("한마음선원", entry.name);
+  return parts.filter(Boolean).join(" ");
+}
+
+function createMapEmbedUrl(entry) {
+  const query = encodeURIComponent(createMapQuery(entry));
+  return `https://maps.google.com/maps?q=${query}&output=embed`;
+}
+
+function createMapSearchUrl(entry) {
+  const query = encodeURIComponent(createMapQuery(entry));
+  return `https://www.google.com/maps/search/?api=1&query=${query}`;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderSupportSection(domesticSupports, "domestic-list", "domestic-detail");
+  renderSupportSection(globalSupports, "global-list", "global-detail");
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,317 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: #f8f9fb;
+  --card-bg: rgba(255, 255, 255, 0.9);
+  --border-color: rgba(15, 35, 95, 0.08);
+  --accent-color: #1e5db5;
+  --text-color: #1e2a3a;
+  --muted-text: #5f6b7a;
+  --shadow-color: rgba(17, 43, 87, 0.08);
+  --shadow-strong: rgba(17, 43, 87, 0.18);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Noto Sans KR", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: linear-gradient(180deg, #eef3fc 0%, #fdfdff 100%);
+  color: var(--text-color);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.page-header {
+  background: radial-gradient(circle at top left, rgba(30, 93, 181, 0.25), transparent 55%),
+    linear-gradient(135deg, rgba(30, 93, 181, 0.85), rgba(78, 150, 233, 0.85));
+  color: #fff;
+  padding: clamp(3rem, 8vw, 6rem) clamp(1.5rem, 6vw, 5rem);
+  text-align: left;
+  position: relative;
+  overflow: hidden;
+}
+
+.page-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.28), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.18), transparent 40%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.header-content {
+  max-width: 760px;
+  position: relative;
+  z-index: 1;
+}
+
+header h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+}
+
+header p {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+main {
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.25rem, 6vw, 4rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 6vw, 4rem);
+}
+
+.support-section {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 60px var(--shadow-color);
+  padding: clamp(1.75rem, 4vw, 3rem);
+  backdrop-filter: blur(8px);
+}
+
+.section-title {
+  margin-bottom: 1.5rem;
+}
+
+.section-title h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+}
+
+.section-title p {
+  margin: 0.35rem 0 0;
+  color: var(--muted-text);
+}
+
+.support-layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(240px, 1fr);
+  gap: clamp(1rem, 4vw, 2rem);
+  align-items: stretch;
+}
+
+.support-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.support-card {
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.1rem;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  position: relative;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+
+.support-card:hover,
+.support-card:focus {
+  outline: none;
+  transform: translateY(-4px);
+  box-shadow: 0 16px 32px var(--shadow-color);
+  border-color: rgba(30, 93, 181, 0.35);
+}
+
+.support-card:focus-visible {
+  outline: 3px solid rgba(30, 93, 181, 0.45);
+  outline-offset: 2px;
+}
+
+.support-card.active {
+  border: 1.5px solid var(--accent-color);
+  box-shadow: 0 20px 40px var(--shadow-strong);
+  background: #fff;
+}
+
+.support-card .name {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin-bottom: 0.35rem;
+}
+
+.support-card .region {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--muted-text);
+}
+
+.support-card .summary {
+  font-size: 0.9rem;
+  color: var(--muted-text);
+  line-height: 1.5;
+}
+
+.support-detail {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.75));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(30, 93, 181, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 16px 40px var(--shadow-color);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 380px;
+}
+
+.detail-header h3 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.4vw, 1.8rem);
+  font-weight: 700;
+  color: var(--accent-color);
+}
+
+.detail-header .region-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(30, 93, 181, 0.08);
+  color: var(--accent-color);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  margin-top: 0.5rem;
+}
+
+.detail-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.detail-body .info-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.info-block dt {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.info-block dd {
+  margin: 0;
+  color: var(--muted-text);
+  font-size: 0.95rem;
+}
+
+.info-block a {
+  color: var(--accent-color);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.info-block a:hover {
+  text-decoration: underline;
+}
+
+.map-link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: var(--accent-color);
+  color: #fff;
+  padding: 0.6rem 1rem;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(30, 93, 181, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.map-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(30, 93, 181, 0.25);
+}
+
+.map-container {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(30, 93, 181, 0.1);
+}
+
+.map-container iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.page-footer {
+  text-align: center;
+  padding: 2.5rem 1rem 3.5rem;
+  color: var(--muted-text);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+  .support-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .support-detail {
+    min-height: unset;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(180deg, #0f172a 0%, #111827 100%);
+    color: rgba(237, 243, 255, 0.96);
+  }
+
+  .support-section {
+    background: rgba(13, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    box-shadow: 0 24px 60px rgba(2, 6, 23, 0.5);
+  }
+
+  .support-card {
+    background: rgba(15, 23, 42, 0.55);
+    border-color: rgba(148, 163, 184, 0.16);
+  }
+
+  .support-card.active {
+    background: rgba(15, 28, 57, 0.85);
+  }
+
+  .support-detail {
+    background: linear-gradient(135deg, rgba(17, 24, 39, 0.95), rgba(17, 24, 39, 0.75));
+    border-color: rgba(148, 163, 184, 0.16);
+  }
+
+  .map-container {
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.14);
+  }
+
+  .page-footer {
+    color: rgba(203, 213, 225, 0.75);
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page experience for browsing domestic and overseas Hanmaum Seonwon support centers with contact information
- implement data-driven rendering with clickable cards that surface Google Maps embeds, dialing links, and external websites
- style the layout for desktop and mobile views with light and dark theme support

## Testing
- Not applicable (static site)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_690bba85be188325aa5c0ecf3c9a84fa)